### PR TITLE
Adding a tensor trait

### DIFF
--- a/src/quick_math/matrix.rs
+++ b/src/quick_math/matrix.rs
@@ -7,7 +7,7 @@ use rand::random;
 
 use crate::quick_grad::{grad_tape::GradTape, var::Var};
 
-use super::errors::MatrixError;
+use super::{errors::MatrixError, tensor::Tensor};
 
 /// # Struct **Matrix**
 /// A classic implementation of the Matrix data structure
@@ -178,6 +178,67 @@ impl<T: Copy> Matrix<T> {
             cols: self.cols * times,
             data,
         }
+    }
+}
+
+impl<T: Copy> Tensor<T> for Matrix<T> {
+    fn get_data(&self) -> &Vec<T> {
+        &self.data
+    }
+
+    fn get_data_mut(&mut self) -> &mut Vec<T> {
+        &mut self.data
+    }
+
+    fn map(&self, f: fn(T) -> T) -> Self {
+        Matrix {
+            rows: self.rows,
+            cols: self.cols,
+            data: self.data.iter().copied().map(f).collect::<Vec<_>>(),
+        }
+    }
+
+    fn reshape(&self, shape: Vec<usize>) -> Self {
+        Matrix {
+            rows: shape[0],
+            cols: shape[1],
+            data: self.data.clone(),
+        }
+    }
+
+    fn cat(&self, other: &Self, axis: usize) -> Self {
+        if axis == 0 {
+            let mut data = self.data.clone();
+            data.extend(other.data.clone());
+            Matrix {
+                rows: self.rows + other.rows,
+                cols: self.cols,
+                data,
+            }
+        } else {
+            let mut data = vec![];
+            for i in 0..self.rows {
+                data.extend(self.get_row_slice(i).to_vec());
+                data.extend(other.get_row_slice(i).to_vec());
+            }
+            Matrix {
+                rows: self.rows,
+                cols: self.cols + other.cols,
+                data,
+            }
+        }
+    }
+
+    fn into_matrix(&self) -> Matrix<T> {
+        Matrix {
+            rows: self.rows,
+            cols: self.cols,
+            data: self.data.clone(),
+        }
+    }
+
+    fn get_shape(&self) -> Vec<usize> {
+        vec![self.rows, self.cols]
     }
 }
 

--- a/src/quick_math/tensor.rs
+++ b/src/quick_math/tensor.rs
@@ -1,14 +1,37 @@
-// use super::matrix::Matrix;
-// pub struct Tensor {
-//     data: Vec<f64>,
-//     shape: Vec<usize>,
-// }
-//
-// impl From<Matrix> for Tensor {
-//     fn from(value: Matrix) -> Self {
-//         Tensor {
-//             data: value.get_data().clone(),
-//             shape: vec![value.get_rows(), value.get_cols()],
-//         }
-//     }
-// }
+use super::matrix::Matrix;
+
+/// # Tensor Trait
+/// This trait defines the basic operations that a tensor should have.
+/// A tensor is a generalization of a matrix
+/// It should add interoperability between matrices and ndarrays
+pub trait Tensor<T: Copy> {
+    /// # Get Data
+    /// Returns a reference to the data of the tensor
+    fn get_data(&self) -> &Vec<T>;
+    /// # Get Data Mut
+    /// Returns a mutable reference to the data of the tensor
+    fn get_data_mut(&mut self) -> &mut Vec<T>;
+    /// # Map
+    /// Returns a new tensor with the function applied to each element
+    fn map(&self, f: fn(T) -> T) -> Self;
+    /// # Reshape
+    /// Returns a new tensor with the shape specified
+    /// The number of elements must be the same
+    fn reshape(&self, shape: Vec<usize>) -> Self;
+    /// # Cat
+    /// Returns a new tensor with the other tensor concatenated
+    fn cat(&self, other: &Self, axis: usize) -> Self;
+    /// # Into Matrix
+    /// Returns a matrix with the data of the tensor
+    fn into_matrix(&self) -> Matrix<T>;
+    /// # Get Shape
+    /// Returns the shape of the tensor
+    fn get_shape(&self) -> Vec<usize>;
+
+    fn apply(&mut self, f: fn(T) -> T) {
+        let data = self.get_data_mut();
+        for i in 0..data.len() {
+            data[i] = f(data[i]);
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a Tensor trait that is supposed to be implemented for Matrices, and a N-dimensional array class, with the aim to introduce interoperability and polymorphism between the two classes (and potentially more, e.g. special structs for GPU-allocated tensors, or for AD-powered tensors)